### PR TITLE
Create Releases in this github repository automaticaly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: 4pilaresAdvisor Release
+
+on: 
+  push:
+    paths:
+    - "*.ex5"
+    - ".github/workflows/*.yml"
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Get version tag
+      id: get_version
+      run: echo ::set-output name=VERSION::$(iconv -f utf-16 -t utf-8 4PilaresAdvisor.mq5 | grep version | sed -r 's/.+"(.+)".+/\1/')
+
+    - uses: rlespinasse/github-slug-action@1.1.1
+    - name: Print slug variables
+      run: |
+        echo ${{ env.GITHUB_REF_SLUG }}
+        echo ${{ env.GITHUB_HEAD_REF_SLUG }}
+        echo ${{ env.GITHUB_BASE_REF_SLUG }}
+      
+    - name: Upload ex5
+      uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        automatic_release_tag: ${{ env.GITHUB_REF_SLUG }}
+        prerelease: false
+        title: ${{ steps.get_version.outputs.VERSION }}
+        files: |
+          *.ex5


### PR DESCRIPTION
@gustavosouzalima , to compartilhando essa pequena idéia de automação. Quando você lançar uma versão nova e dar um push no código, enviando um novo ex5, o github vai automaticamente ler o mq5 e gerar uma Release nova pra deixar arquivado no sistema, tipo assim:

![](https://user-images.githubusercontent.com/2002125/108121367-7884e700-7081-11eb-9fa7-5bc663b92d4d.png)

Dessa forma você pode manter um histórico das Release:

![](https://user-images.githubusercontent.com/2002125/108121446-981c0f80-7081-11eb-8a7b-0c8c4d470c14.png)